### PR TITLE
feat: Add render prop to use custom component/element

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,31 @@ More details can be found in the official Google docs:
  * [GoogleAuth.signIn(options)](https://developers.google.com/identity/sign-in/web/reference#googleauthsigninoptions)
  * [GoogleAuth.grantOfflineAccess(options)](https://developers.google.com/identity/sign-in/web/reference#googleauthgrantofflineaccessoptions)
 
+## Using a custom element
+
+If you prefer, you can use your own custom JSX/React component instead of the default authorization button.
+
+Just make sure to bind the `renderProps.onClick` as your component prop `onClick` listener, in other that to call the 
+properly authorization function like the example below:
+
+```js
+  <GoogleAuthorize
+    clientId={'815121234598-5nn3e2ftm5hobdjbemuappb2t112345.apps.googleusercontent.com'}
+    onSuccess={responseGoogle}
+    onFailure={responseGoogle}
+    render={(renderProps) => {
+      return (
+        <button
+          type="button"
+          onClick={renderProps.onClick}
+        >
+          My custom element
+        </button>
+      )
+    }}
+  />
+```
+
 ## Dev Server
 ```
 yarn run start

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ReactDOM.render(
 | uxMode       |  string  |  popup   | The UX mode to use for the sign-in flow. Valid values are popup and redirect. |
 | redirectUri       |  string  |  -   | If using ux_mode='redirect', this parameter allows you to override the default redirect_uri that will be used at the end of the consent flow. The default redirect_uri is the current URL stripped of query parameters and hash fragment. |
 | isSignedIn | boolean | false | If true will return GoogleUser object on load, if user has given your app permission |
-
+| render | function | - | Render prop to use a custom element, use renderProps.onClick |
 Google Scopes List: https://developers.google.com/identity/protocols/googlescopes
 
 ## onSuccess callback

--- a/src/GoogleAuthorize.js
+++ b/src/GoogleAuthorize.js
@@ -98,9 +98,12 @@ class GoogleAuthorize extends Component {
 
   render() {
     const {
-      tag, type, style, className, disabledStyle, buttonText, children
+      tag, type, style, className, disabledStyle, buttonText, children, render
     } = this.props;
     const disabled = this.state.disabled || this.props.disabled;
+    if (render) {
+      return render({ onClick: this.handleClick })
+    }
     const initialStyle = {
       display:       'inline-block',
       background:    '#d14836',
@@ -166,7 +169,8 @@ GoogleAuthorize.propTypes = {
   discoveryDocs:     PropTypes.array,
   uxMode:            PropTypes.string,
   responseType:      PropTypes.string,
-  type:              PropTypes.string
+  type:              PropTypes.string,
+  render:            PropTypes.func
 };
 
 GoogleAuthorize.defaultProps = {

--- a/test/google_test.js
+++ b/test/google_test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { renderComponent, expect } from './test_helper';
 import { GoogleAuthorize } from '../src/index';
 
@@ -214,5 +215,33 @@ describe('Google Authorize', () => {
         it('displays a div element when tag prop is set to div', () => {
             expect(component.get(0).tagName).to.equal('DIV');
         });
+    });
+    describe('With custom render prop', () => {
+        beforeEach(() => {
+            propsObj = {
+                onSuccess(response) { },
+                onFailure(response) { },
+                render(renderProps) {
+                  return (
+                    <button id="my-component" onClick={renderProps.onClick} />
+                  );
+                },
+                clientId: '815121234598-5nn3e2ftm5hobdjbemuappb2t112345.apps.googleusercontent.com',
+            };
+            component = renderComponent(GoogleAuthorize, propsObj);
+        });
+
+        it('shows the button', () => {
+            expect(component).to.exist;
+        });
+
+        it('displays a button element when render prop is defined', () => {
+            expect(component.get(0).tagName).to.equal('BUTTON');
+        });
+
+        it('displays the custom element attribute when render prop is defined', () => {
+            expect(component.get(0).id).to.equal('my-component');
+        });
+
     });
 });


### PR DESCRIPTION
Hello,

First, thank you for this awesome module!

I came from the module `react-google-login`, from your closed issue [#156](https://github.com/anthonyjgrove/react-google-login/issues/156). Like you, I was in trouble with oauth2 scopes when multiple buttons were displayed at the same screen. This module solved my tree days of headache trying to track the bug.

In this pull request, I added the render prop (same as `react-google-login`) to display a custom element instead of the default.

I really appreciate with you accept this pull request and push this new version to `npm`.

Thank you!

