### PR TITLE
Add response_type to params

### DIFF
--- a/src/GoogleAuthorize.js
+++ b/src/GoogleAuthorize.js
@@ -73,7 +73,6 @@ class GoogleAuthorize extends Component {
 
     if (params.response_type === 'code') {
       params.access_type = 'offline';
-      params.response_type = 'code';
     }
 
     onRequest();


### PR DESCRIPTION
There's handling for `responseType="code"` but it's hard-coded.

Google allows `responseType="id_token token"` which is in the README table, but it is not actually passed to `params`.